### PR TITLE
Remove extra clone() in recover_secret().

### DIFF
--- a/rust/src/math.rs
+++ b/rust/src/math.rs
@@ -400,6 +400,15 @@ impl<'a> Sub<&'a FE> for FE {
         self - *rhs
     }
 }
+
+impl<'a, 'b> Sub<&'b FE> for &'a FE {
+    type Output = FE;
+
+    fn sub(self, rhs: &'b FE) -> FE {
+        *self - *rhs
+    }
+}
+
 impl<'a> Mul<&'a FE> for FE {
     type Output = Self;
     fn mul(self, rhs : &Self) -> FE {


### PR DESCRIPTION
First, we have to define `Sub` for the case when both field elements are references (`impl<'a, 'b> Sub<&'b FE> for &'a FE`).

Next, in order to work generically, as in the case of

```rust
pub fn recover_secret<N>(shares : &[Share<N>]) -> N
    where N : NumRef + Clone
```

we need to specify a trait bound that all `N` will have subtraction defined when operating on their borrowed selves, so we change it to

```rust
pub fn recover_secret<N>(shares: &[Share<N>) -> N
    where &'a N: Sub<&'b N>,
              N: NumRef + Clone,
```

This is not enough, because now, after subtracting `&sh2.x - &sh.x` this is going to result in whatever the hell the type of `&N as Sub<&'b N>::Output` is, which (generically over `N`) we've no idea.  Also it's probably complaining about unspecified lifetimes at this point. So we change the `where` clause again to

```rust
pub fn recover_secret<'a, 'b, N>(shares: &'b [Share<N>]) -> N
    where &'a N: Sub<&'b N, Output = N>,
              N: NumRef + Clone,
```
Now the compiler knows that the `Output` is going to be something it can multiply. (Oops, except we didn't explicitly tell it that it could multiply by saying `N: Mul<N>`, but it seems to be finding this trait implementation okay…)

This, combined with the iterators over borrowed data (the `&[Share<N]`), requires specifying lifetimes to ensure that while the `impl<'a, 'b> Sub<&'b FE> for &'a FE` says it works on two _distinct_ lifetimes, we're telling `recover_secret()` that in this case we'll only ever be giving it lifetimes which are equivalent (they're all coming from the same `&[Share<N>]`). (This starts to make more sense if you think of lifetimes as a _kind_, or a family of related types. Or it did for me.) Also, we can remove `Clone`. So, the final `where` clause ends up being:

```rust
pub fn recover_secret<'a, N>(shares: &'a [Share<N>]) -> N
    where &'a N: Sub<&'a N, Output = N>,
              N: NumRef + 'a,
```

Then we can remove the `ref` markers from the declarations in the `for` loops (they're elided in any rustc newer than 1.14 or so), remove the `.clone()` and change `sh2` to be a reference.
